### PR TITLE
change user create date from text to date

### DIFF
--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -20,7 +20,7 @@
 
             <div class="form-item">
                 {!! Form::label('start_date', 'Start Date: ', array('class' => 'field-label')) !!}
-                {!! Form::text('start_date', NULL, ['class' => 'text-field', 'placeholder' => 'MM/DD/YYYY']) !!}
+                {!! Form::date('start_date', NULL, ['class' => 'text-field', 'placeholder' => 'MM/DD/YYYY']) !!}
             </div>
 
             <div class="form-item">


### PR DESCRIPTION
Fixes #21 

edit user looks like this:
![image](https://cloud.githubusercontent.com/assets/4240292/13013311/ea2babcc-d17c-11e5-9c63-706b99b5ec0c.png)

create user looks like this:
![image](https://cloud.githubusercontent.com/assets/4240292/13013321/f49c4e2c-d17c-11e5-8c6e-8da005654a7a.png)

Everything goes into the DB right as long as the person adding/editing sticks with the format given to them on whichever page.

cc: @sbsmith86 
